### PR TITLE
Enable to compile for arduino boards

### DIFF
--- a/A6lib.cpp
+++ b/A6lib.cpp
@@ -2,6 +2,10 @@
 #include <SoftwareSerial.h>
 #include "A6lib.h"
 
+#ifdef ESP8266
+    #define min _min
+    #define max _max
+#endif	
 
 /////////////////////////////////////////////
 // Public methods.
@@ -341,11 +345,7 @@ void A6lib::setVol(byte level) {
     char buffer[30];
 
     // level should be between 5 and 8.
-	#ifdef ESP8266
-		level = _min(_max(level, 5), 8);
-	#else
-		level = min(max(level, 5), 8);	
-	#endif
+	level = min(max(level, 5), 8);	
     sprintf(buffer, "AT+CLVL=%d", level);
     A6command(buffer, "OK", "yy", A6_CMD_TIMEOUT, 2, NULL);
 }
@@ -357,11 +357,7 @@ void A6lib::enableSpeaker(byte enable) {
     char buffer[30];
 
     // enable should be between 0 and 1.
-	#if defined(ESP8266
-		enable = _min(_max(enable, 0), 1);
-	#else
-		enable = min(max(enable, 0), 1);
-	#endif	
+	enable = min(max(enable, 0), 1);
     sprintf(buffer, "AT+SNFS=%d", enable);
     A6command(buffer, "OK", "yy", A6_CMD_TIMEOUT, 2, NULL);
 }

--- a/A6lib.cpp
+++ b/A6lib.cpp
@@ -341,7 +341,11 @@ void A6lib::setVol(byte level) {
     char buffer[30];
 
     // level should be between 5 and 8.
-    level = _min(_max(level, 5), 8);
+	#ifdef ESP8266
+		level = _min(_max(level, 5), 8);
+	#else
+		level = min(max(level, 5), 8);	
+	#endif
     sprintf(buffer, "AT+CLVL=%d", level);
     A6command(buffer, "OK", "yy", A6_CMD_TIMEOUT, 2, NULL);
 }
@@ -353,7 +357,11 @@ void A6lib::enableSpeaker(byte enable) {
     char buffer[30];
 
     // enable should be between 0 and 1.
-    enable = _min(_max(enable, 0), 1);
+	#if defined(ESP8266
+		enable = _min(_max(enable, 0), 1);
+	#else
+		enable = min(max(enable, 0), 1);
+	#endif	
     sprintf(buffer, "AT+SNFS=%d", enable);
     A6command(buffer, "OK", "yy", A6_CMD_TIMEOUT, 2, NULL);
 }


### PR DESCRIPTION
Currently build is working with esp8266 but not with arduino. By adding macro depending on the board we can build now the library on Arduino or ESP8266.